### PR TITLE
Add post install script to auto install poly fill dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
 		"": {
 			"name": "immersive-web-emulator",
 			"version": "1.0.1",
+			"hasInstallScript": true,
 			"dependencies": {
 				"bootstrap": "^5.2.3",
 				"jquery": "^3.6.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"lint": "eslint ./src",
 		"format": "prettier --write ./src/**/*",
 		"watch": "npm-watch",
+		"postinstall": "cd polyfill && npm install",
 		"zip": "npm run build && bestzip iwe-release.zip dist/* icons/* manifest.json LICENSE.md"
 	},
 	"pre-commit": [


### PR DESCRIPTION
Currently, the `npm run build` command requires the polyfill package to be installed, but this is not installed by default. This PR adds a `postinstall` script to automatically install these dependencies.