### PR TITLE
[Feature] MVP Immersive AR Support

### DIFF
--- a/polyfill/EmulatedXRDevice.js
+++ b/polyfill/EmulatedXRDevice.js
@@ -873,9 +873,9 @@ let SESSION_ID = 0;
 class Session {
 	constructor(mode, enabledFeatures) {
 		this.mode = mode;
-		this.immersive = mode == 'immersive-vr';
+		this.immersive = mode == 'immersive-vr' || mode == 'immersive-ar';
 		this.vr = mode === 'immersive-vr';
-		this.ar = false;
+		this.ar = mode == 'immersive-ar';
 		this.id = ++SESSION_ID;
 		this.baseLayer = null;
 		this.inlineVerticalFieldOfView = Math.PI * 0.5;

--- a/src/devtool/js/devices.js
+++ b/src/devtool/js/devices.js
@@ -118,7 +118,7 @@ export const DEVICE_DEFINITIONS = {
 		id: 'Oculus Quest 2',
 		name: 'Oculus Quest 2',
 		profile: 'oculus-touch-v3',
-		modes: ['inline', 'immersive-vr'],
+		modes: ['inline', 'immersive-vr', 'immersive-ar'],
 		headset: {
 			hasPosition: true,
 			hasRotation: true,
@@ -154,7 +154,7 @@ export const DEVICE_DEFINITIONS = {
 		id: 'Meta Quest Pro',
 		name: 'Meta Quest Pro',
 		profile: 'meta-quest-touch-pro',
-		modes: ['inline', 'immersive-vr'],
+		modes: ['inline', 'immersive-vr', 'immersive-ar'],
 		headset: {
 			hasPosition: true,
 			hasRotation: true,


### PR DESCRIPTION
Simply adds `immersive-ar` support to the WebXR polyfill supported modes, as well as runs the correct logic in various matrix calculations to render an immersive VR session the same as an immersive AR session.

Future considerations include mobile (non-immersive) AR compatibility. I believe the original Mozilla WebXR Emulator included a primitive version of this (with no AR specific WebXR features) but a lot of those code paths seem to not be included in this revamp.

## References
https://github.com/meta-quest/immersive-web-emulator/issues/1

This contibution is funded by [Ethereal Engine](https://etherealengine.org)