### PR TITLE
Permissions for dynamically created frames

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,8 @@
 			"matches": ["http://*/*", "https://*/*"],
 			"js": ["dist/content.js"],
 			"run_at": "document_start",
-			"all_frames": true
+			"all_frames": true,
+			"match_origin_as_fallback": true
 		}
 	],
 	"action": {

--- a/src/extension/service-worker.js
+++ b/src/extension/service-worker.js
@@ -31,6 +31,7 @@ const updateInjection = (reloadTabId = null) => {
 							allFrames: true,
 							runAt: 'document_start',
 							world: 'MAIN',
+							matchOriginAsFallback: true,
 							excludeMatches: Array.from(
 								EmulatorSettings.instance.polyfillExcludes,
 							),


### PR DESCRIPTION
Some online editors, such as the p5.js web editor, create dynamic iframes that don't match the URL of the parent, as I tried to explain in #64. The permission change in this PR enables the polyfill in these contexts. Here is the related [documentation](https://developer.chrome.com/docs/extensions/develop/concepts/content-scripts#injecting-in-related-frames
). 

I setup a minimal example with the barebones-ar immersive example [here] to validate it working. (https://editor.p5js.org/TiborUdvari/sketches/zW9qJtK7V). 

I thought that having the permission in the script injected by the service worker would be enough, but through some trial and error I found this is the minimal permission change to make it work. For future reference, there is also a `match_about_blank` permission that might be needed in some cases, although not mine.

Here, it is working in the editor after the changes.

<img width="1781" alt="Screenshot 2024-08-26 at 14 36 25" src="https://github.com/user-attachments/assets/2a87aefa-a55c-4190-912a-d726329360b9">


